### PR TITLE
Fix BigMouthPatch

### DIFF
--- a/LiarsBarEnhance/Features/BigMouthPatch.cs
+++ b/LiarsBarEnhance/Features/BigMouthPatch.cs
@@ -6,17 +6,15 @@ namespace LiarsBarEnhance.Features;
 [HarmonyPatch]
 public class BigMouthPatch
 {
-    [HarmonyPatch(typeof(CharController), nameof(CharController.Update))]
+    [HarmonyPatch(typeof(FaceAnimator), "Update")]
     [HarmonyPostfix]
-    public static void UpdatePostfix(CharController __instance)
+    public static void UpdatePostfix(FaceAnimator __instance)
     {
         if (!__instance.isOwned)
             return;
 
-        var mouth = __instance.HeadPivot.Find("Base HumanHead/Mouth");
+        Vector3 pos = __instance.Mouth.transform.localPosition;
         if (Input.GetKey(KeyCode.O))
-            mouth.transform.localPosition = new Vector3(0.5f, 0.2f, 0f);
-        if (Input.GetKeyUp(KeyCode.O))
-            mouth.transform.localPosition = Vector3.zero;
+            __instance.Mouth.transform.localEulerAngles = new Vector3(pos.x, pos.y, 300f);
     }
 }


### PR DESCRIPTION
As mentioned in #24, the current method used to open the mouth is no longer synchronised across all clients. 
This is fixed by setting localEulerAngles instead of the localPosition. 